### PR TITLE
Changes to the Perl HTML generating functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ ftp/
 #  lib may be created during installs but should not be committed
 lib/
 man/
+
+# Datafiles may be created and modified by Update_website.pl, but 
+# they do not have to be committed
+datafiles/
+tmp/

--- a/bin/Update_website.pl
+++ b/bin/Update_website.pl
@@ -20,7 +20,6 @@ use vars qw(%RDFData %replacers @rdfFiles);
 my $webroot = dirname($0) . "/.." ;
 $webroot = $ENV{'MUTOPIA_WEB'} || $webroot;
 $webroot =~ s|\\|/|g; # change MSDOS file separators
-print "Using $webroot as the webroot\n"; #DEBUG
 
 # Generate datafiles/*  ####################################################
 my @files = getRDFFileList("$webroot/ftp/");
@@ -125,7 +124,7 @@ sub makeCache {
 
     open TEMPCACHE, ">:utf8", "$webroot/datafiles/tempmusiccache.dat"
         or die "cannot open >$webroot/datafiles/tempmusiccache.dat: $!";
-	binmode TEMPCACHE; # Be sure we're writing Unix line endings (LF)
+	binmode(TEMPCACHE, ":raw:utf8"); # Be sure we're writing Unix line endings (LF)
 	
     for (sort {byFileName($a,$b)} keys %RDFData) {
         my ($opus, $name) = m|^(?:\./)?(.*)/([^/]+)/[^/]+.rdf$| or die "invalid piece: $_";
@@ -179,7 +178,7 @@ sub makeCache {
 		or die "cannot open $webroot/datafiles/tempmusiccache.dat";
     open CACHE, ">:utf8", "$webroot/datafiles/musiccache.dat"
         or die "cannot open >$webroot/datafiles/musiccache.dat: $!";
-	binmode CACHE; # Write with Unix line endings
+	binmode(CACHE, ":raw:utf8"); # Be sure we're writing Unix line endings (LF)
 	
 	my @offsets;
 	my $piecenumber = 0;

--- a/bin/Update_website.pl
+++ b/bin/Update_website.pl
@@ -7,16 +7,20 @@
 #  and updates index page (if required)
 
 use strict;           # Must declare variables with "my" or "use vars"
-use File::Basename;
+use File::Basename;   # dirname() 
+use File::Find;       # find()
+use Cwd;              # getcwd()
 use Mutopia_Archive;  # subroutines for manipulating the archive
 use Mutopia_HTMLGen;  # subroutines for generating HTML
-use vars qw(%RDFData %replacers);
+use vars qw(%RDFData %replacers @rdfFiles);
 
 # Find the root of our data by assuming the script we are executing is
 # in a 'bin' folder which is a sibling to 'datafiles'. Allow an
-# environment variable WEBROOT to override this.
+# environment variable MUTOPIA_WEB to override this.
 my $webroot = dirname($0) . "/.." ;
-$webroot = ( exists $ENV{'MUTOPIA_WEB'} ? $ENV{'MUTOPIA_WEB'} : $webroot );
+$webroot = $ENV{'MUTOPIA_WEB'} || $webroot;
+$webroot =~ s|\\|/|g; # change MSDOS file separators
+print "Using $webroot as the webroot\n"; #DEBUG
 
 # Generate datafiles/*  ####################################################
 my @files = getRDFFileList("$webroot/ftp/");
@@ -33,13 +37,19 @@ Mutopia_HTMLGen::makeHTML(\%RDFData);
 #
 sub getRDFFileList {
     my $basedir = shift;
-    chomp (my $olddir = `pwd`);
-    chdir $basedir or die "Cannot chdir to $basedir: $!";
-    my @files = sort {byFileName($a,$b)} `find . -name "*.rdf"`; # XXX File::Find
+	find(\&wanted, $basedir); # side effect, adds to @rdfFiles
+    my @files = sort {byFileName($a,$b)} @rdfFiles;
     s/\s*//g for @files;
     die "Can't find any *.rdf files below $basedir" unless @files;
-    chdir $olddir or die "Cannot return to directory $olddir: $!";
     return @files;
+}
+
+# Used by find(), equivalent to `find . -name "*.rdf"`
+# Uses global @rdfFiles
+#
+sub wanted {
+    /^.*\.rdf\z/s
+    && (push @rdfFiles, $File::Find::name);
 }
 
 # byFileName($a, $b)
@@ -76,7 +86,7 @@ sub byFileName($$) {
 sub getAllRDFData {
     my ($basedir, @files) = @_;
     my %data;
-    chomp(my $olddir = `pwd`);
+    my $olddir = getcwd();
     chdir $basedir or die "Cannot chdir to $basedir: $!";
     for my $file (@files) {
         $file =~ m|^(.*)/([^/]+)$| or die "bad filename: $file";
@@ -109,10 +119,14 @@ sub makeCache {
         chomp($printurls[$noOfPrintUrls] = <PRINTURLS>);
     }
     close (PRINTURLS);
+	
+	# Use Unix text record endings or seek will be off in Windows
+	local $/ = "\n";
 
     open TEMPCACHE, ">:utf8", "$webroot/datafiles/tempmusiccache.dat"
         or die "cannot open >$webroot/datafiles/tempmusiccache.dat: $!";
-
+	binmode TEMPCACHE; # Be sure we're writing Unix line endings (LF)
+	
     for (sort {byFileName($a,$b)} keys %RDFData) {
         my ($opus, $name) = m|^(?:\./)?(.*)/([^/]+)/[^/]+.rdf$| or die "invalid piece: $_";
         my @data = Mutopia_Archive::RDFtoCACHE %{ $RDFData{$_} };
@@ -159,10 +173,14 @@ sub makeCache {
     # Also, offsets are padded up to ~10Mb (10000000). Again, if the cache gets
     #       bigger than this, things will break
 
-    open (TEMPCACHE, '<:utf8', "$webroot/datafiles/tempmusiccache.dat") or die "cannot open $webroot/datafiles/tempmusiccache.dat";
+	local $/ = "\n"; # Read text with Unix line endings
+	
+    open (TEMPCACHE, '<:utf8', "$webroot/datafiles/tempmusiccache.dat") 
+		or die "cannot open $webroot/datafiles/tempmusiccache.dat";
     open CACHE, ">:utf8", "$webroot/datafiles/musiccache.dat"
         or die "cannot open >$webroot/datafiles/musiccache.dat: $!";
-
+	binmode CACHE; # Write with Unix line endings
+	
 	my @offsets;
 	my $piecenumber = 0;
 
@@ -227,7 +245,8 @@ sub makeCache {
 	close(TEMPCACHE);
 	close(CACHE);
 
-	unlink "datafiles/tempmusiccache.dat";
+	unlink "$webroot/datafiles/tempmusiccache.dat"
+			or warn "Cannot delete $webroot/datafiles/tempmusiccache.dat";
 }
 
 # makeSearchCache()
@@ -271,5 +290,6 @@ sub makeSearchCache {
     print SEARCHCACHE "$_\n" for @sorteddata;
     close (SEARCHCACHE);
 
-    unlink "datafiles/tempsearchcache.dat";
+    unlink "$webroot/datafiles/tempsearchcache.dat"
+			or warn "Cannot delete $webroot/datafiles/tempsearchcache.dat";
 }

--- a/src/Mutopia_Archive/lib/Mutopia_Archive.pm
+++ b/src/Mutopia_Archive/lib/Mutopia_Archive.pm
@@ -8,8 +8,14 @@
 
 package Mutopia_Archive;
 use strict;
+use Carp; # croak() - like die() but error appears in the caller
 
 our $VERSION = '0.02';
+
+# Files must be opened from webroot
+my $webroot = $ENV{'MUTOPIA_WEB'} 
+	or croak "MUTOPIA_WEB environment variable must be set\n";
+$webroot =~ s|\\|/|g; # change MSDOS file separators
 
 # readRDFFile($filename)
 # reads an RDF file, and returns a data structure.
@@ -24,7 +30,7 @@ sub readRDFFile {
 	# use the XPath object to find relevant nodes in XML tree
 	my @nodes = $xp->find("/rdf:RDF/rdf:Description/*")->get_nodelist();
 
-    die "Can't find /rdf:RDF/rdf:Description/* nodes" if @nodes == 0;
+    croak "Can't find /rdf:RDF/rdf:Description/* nodes" if @nodes == 0;
     
     # read data from each relevant node, putting it into a hash
 	my %data = ();
@@ -33,7 +39,7 @@ sub readRDFFile {
 	    $value =~ s/\s+/ /gs;  # normalise whitespace
 		my $fieldname = $node->getName();
 		$fieldname =~ s/^mp://
-            or die "fieldname breaks namespace kludge: $fieldname";
+            or croak "fieldname breaks namespace kludge: $fieldname";
 		$data{ $fieldname } = $value;
 	}
 
@@ -46,7 +52,7 @@ sub readRDFFile {
 #
 sub getData {
     my $file = shift;
-    open (FILE, '<:utf8', $file) or die "cannot open $file: $!";
+    open (FILE, '<:utf8', $file) or croak "cannot open $file: $!";
     return map { chomp; $_ } <FILE>;
 }
 
@@ -61,7 +67,7 @@ sub RDFtoCACHE {
 	# version on 20/Jun/2003 (while waiting for Harry Potter 5...)
 	# Beware of old scripts! [Chris]
 	
-	my %comp  = getData("datafiles/composers.dat");
+	my %comp  = getData("$webroot/datafiles/composers.dat");
 	my @cachedata = ();
 	push @cachedata, $rdf{lyFile};
 	push @cachedata, $rdf{midFile};
@@ -103,7 +109,7 @@ sub RDFtoCACHE {
 sub RDFtoSEARCHCACHE {
 	my %rdf = @_;
 
-    my %comp  = getData("datafiles/composers.dat");
+    my %comp  = getData("$webroot/datafiles/composers.dat");
 	my @searchcachedata = ();
 	push @searchcachedata, "title:" . $rdf{title} . ":";
 

--- a/src/Mutopia_HTMLGen/lib/Mutopia_HTMLGen.pm
+++ b/src/Mutopia_HTMLGen/lib/Mutopia_HTMLGen.pm
@@ -9,6 +9,9 @@ package Mutopia_HTMLGen;
 use Mutopia_Archive; # helpful subroutines
 use POSIX qw(strftime);
 use Time::Local;
+use Carp; # croak() = like die(), but the error appears in the caller
+use Cwd;  # getcwd(), like `pwd`
+use File::Path qw(make_path remove_tree);
 use utf8;
 use vars qw(%RDF_DATA);
 
@@ -17,19 +20,29 @@ our $VERSION = '0.02';
 my %RDF_DATA;
 my $OUTPUT_FILE;
 
+# File opens must be relative to webroot
+my $webroot = $ENV{'MUTOPIA_WEB'}
+	or croak("The environment variable MUTOPIA_WEB must be set\n");
+$webroot =~ s|\\|/|g; # Change MSDOS file separators
+
 # makeHTML(\%RDF_DATA)
 # Read *.html-in, fill with generated data, and write *.html
 #
 sub makeHTML($) {
     my $rdf_ref = shift;
+	
+	# Clear and create an htdocs folder in $webroot for the HTML files
+	remove_tree("$webroot/htdocs");
+	make_path("$webroot/htdocs");
 
     %RDF_DATA = %$rdf_ref;
-    chdir "html-in" or die "cannot chdir to html-in: $!";
+	my $starting_dir = getcwd();
+    chdir "$webroot/html-in" or croak "cannot chdir to html-in: $!";
     my @infiles = glob("*.html-in");
-    chdir "..";
+    chdir $starting_dir;
 
     for my $infile(@infiles) {
-        open (IN, "<:utf8", "html-in/$infile") or die "cannot open $infile: $!";
+        open (IN, "<:utf8", "$webroot/html-in/$infile") or croak "cannot open $infile: $!";
         local $_ = join "", <IN>;
         close IN;
 
@@ -42,32 +55,35 @@ sub makeHTML($) {
 ________EOM
 
         ($OUTPUT_FILE = $infile) =~ s/\.html-in$/.html/
-                or die "invalid filename: $infile";
+                or croak "invalid filename: $infile";
 
         replace_placeholders(\$_);
 
-        open OUT, ">:utf8", "$OUTPUT_FILE" or die "cannot open >$OUTPUT_FILE: $!";
+        open OUT, ">:utf8", "$webroot/htdocs/$OUTPUT_FILE" 
+				or croak "cannot open >$webroot/htdocs/$OUTPUT_FILE: $!";
         print OUT $_;
         close OUT;
 
         undef $OUTPUT_FILE;
     }
 
-    chdir "html-in" or die "cannot chdir to html-in: $!";
+    chdir "$webroot/html-in" or croak "cannot chdir to html-in: $!";
     @infiles = glob("*.rss-in");
-    chdir "..";
+    chdir $starting_dir;
 
     for my $infile(@infiles) {
-        open (IN, "<:utf8", "html-in/$infile") or die "cannot open $infile: $!";
+        open (IN, "<:utf8", "$webroot/html-in/$infile") 
+				or croak "cannot open $webroot/html-in/$infile: $!";
         local $_ = join "", <IN>;
         close IN;
 
         ($OUTPUT_FILE = $infile) =~ s/\.rss-in$/.rss/
-                or die "invalid filename: $infile";
+                or croak "invalid filename: $infile";
 
         replace_placeholders(\$_);
 
-        open OUT, ">:utf8", "$OUTPUT_FILE" or die "cannot open >$OUTPUT_FILE: $!";
+        open OUT, ">:utf8", "$webroot/htdocs/$OUTPUT_FILE" 
+				or croak "cannot open >$webroot/htdocs/$OUTPUT_FILE: $!";
         print OUT $_;
         close OUT;
 
@@ -103,20 +119,20 @@ sub replace_placeholders($) {
 
 
 sub BROWSE_BY_COMPOSER {
-    my %comps = Mutopia_Archive::getData("datafiles/composers.dat");
+    my %comps = Mutopia_Archive::getData("$webroot/datafiles/composers.dat");
     my $html = "";
     for my $k (sort {Mutopia_Archive::byComposer($a,$b)} keys %comps) {
 
         # How many pieces by this composer?
-	open (SEARCHCACHE, '<:utf8', 'datafiles/searchcache.dat')
-        or die "cannot open datafiles/searchcache.dat: $!";
-	my $noofpieces = 0;
-	my $finish = 0;
-	do {
-        chomp(my $templine = <SEARCHCACHE>);
-	    if ($templine =~ /^composerK:$k/) { $noofpieces++ }
-	    if ($templine =~ /^date/) { $finish = 1 }
-        } until (($finish == 1) || (eof SEARCHCACHE));
+		open (SEARCHCACHE, '<:utf8', "$webroot/datafiles/searchcache.dat")
+			or croak "cannot open $webroot/datafiles/searchcache.dat: $!";
+		my $noofpieces = 0;
+		my $finish = 0;
+		do {
+			chomp(my $templine = <SEARCHCACHE>);
+			if ($templine =~ /^composerK:$k/) { $noofpieces++ }
+			if ($templine =~ /^date/) { $finish = 1 }
+		} until (($finish == 1) || (eof SEARCHCACHE));
         close(SEARCHCACHE);
 
         $html .= "<a href='cgibin/make-table.cgi?Composer=$k'>";
@@ -127,21 +143,21 @@ sub BROWSE_BY_COMPOSER {
 
 
 sub BROWSE_BY_INSTRUMENT {
-    my %insts = Mutopia_Archive::getData("datafiles/instruments.dat");
+    my %insts = Mutopia_Archive::getData("$webroot/datafiles/instruments.dat");
     my $html = "";
     for my $k (sort {Mutopia_Archive::byInstrument($a,$b)} keys %insts) {
 
-    # How many pieces for this instrument?
-	open (SEARCHCACHE, '<:utf8', 'datafiles/searchcache.dat')
-        or die "cannot open datafiles/searchcache.dat: $!";
-	my $noofpieces = 0;
-	my $finish = 0;
-	do {
-        chomp(my $templine = <SEARCHCACHE>);
-	    if ( ($templine =~ /^instruments:/) &&
-	         ( $templine =~ /$k/ )) { $noofpieces++ }
-            if (($k eq "Harp") and ($templine =~ /Harpsichord/)) { $noofpieces-- }
-	    if ($templine =~ /^licence/) { $finish = 1 }
+		# How many pieces for this instrument?
+		open (SEARCHCACHE, '<:utf8', "$webroot/datafiles/searchcache.dat")
+			or croak "cannot open $webroot/datafiles/searchcache.dat: $!";
+		my $noofpieces = 0;
+		my $finish = 0;
+		do {
+			chomp(my $templine = <SEARCHCACHE>);
+			if ( ($templine =~ /^instruments:/) &&
+				 ( $templine =~ /$k/ )) { $noofpieces++ }
+				if (($k eq "Harp") and ($templine =~ /Harpsichord/)) { $noofpieces-- }
+			if ($templine =~ /^licence/) { $finish = 1 }
         } until (($finish == 1) || (eof SEARCHCACHE));
         close(SEARCHCACHE);
 
@@ -153,19 +169,19 @@ sub BROWSE_BY_INSTRUMENT {
 
 
 sub BROWSE_BY_STYLE {
-    my %styles = Mutopia_Archive::getData("datafiles/styles.dat");
+    my %styles = Mutopia_Archive::getData("$webroot/datafiles/styles.dat");
     my $html = "";
     for my $k (sort keys %styles) {
 
-    # How many pieces in this style?
-	open (SEARCHCACHE, '<:utf8', 'datafiles/searchcache.dat')
-            or die "cannot open datafiles/searchcache.dat: $!";
-	my $noofpieces = 0;
-	my $finish = 0;
-	do {
-        chomp(my $templine = <SEARCHCACHE>);
-	    if ($templine =~ /^style:$styles{$k}/) { $noofpieces++ }
-	    if ($templine =~ /^title/) { $finish = 1 }
+		# How many pieces in this style?
+		open (SEARCHCACHE, '<:utf8', "$webroot/datafiles/searchcache.dat")
+				or croak "cannot open $webroot/datafiles/searchcache.dat: $!";
+		my $noofpieces = 0;
+		my $finish = 0;
+		do {
+			chomp(my $templine = <SEARCHCACHE>);
+			if ($templine =~ /^style:$styles{$k}/) { $noofpieces++ }
+			if ($templine =~ /^title/) { $finish = 1 }
         } until (($finish == 1) || (eof SEARCHCACHE));
         close(SEARCHCACHE);
 
@@ -177,7 +193,8 @@ sub BROWSE_BY_STYLE {
 
 
 sub BROWSE_COLLECTIONS {
-    open (COLLECTIONS, '<:utf8', 'datafiles/collections.dat');
+    open (COLLECTIONS, '<:utf8', "$webroot/datafiles/collections.dat")
+			or croak "cannot open $webroot/datafiles/collections.dat: $!";
     my $lineread;
     my $colname;
     my $coldesc;
@@ -200,7 +217,7 @@ sub BROWSE_COLLECTIONS {
 
 
 sub COMPOSER_OPTIONS {
-    my %comps = Mutopia_Archive::getData("datafiles/composers.dat");
+    my %comps = Mutopia_Archive::getData("$webroot/datafiles/composers.dat");
     my $html = "";
     for my $k (sort {Mutopia_Archive::byComposer($a,$b)} keys %comps) {
         $html .= "<option value='$k'>" . $comps{$k} . "</option>\n";
@@ -210,7 +227,7 @@ sub COMPOSER_OPTIONS {
 
 
 sub COMPOSER_LIST {
-    my %comps = Mutopia_Archive::getData("datafiles/composers.dat");
+    my %comps = Mutopia_Archive::getData("$webroot/datafiles/composers.dat");
     my $html = "";
     for my $k (sort {Mutopia_Archive::byComposer($a,$b)} keys %comps) {
         $html .= $k . ", ";
@@ -220,7 +237,7 @@ sub COMPOSER_LIST {
 
 
 sub INSTRUMENT_OPTIONS {
-    my %insts = Mutopia_Archive::getData("datafiles/instruments.dat");
+    my %insts = Mutopia_Archive::getData("$webroot/datafiles/instruments.dat");
     my $html = "";
     for my $k (sort {Mutopia_Archive::byInstrument($a,$b)} keys %insts) {
         $html .= "<option value='$k'>" . $insts{$k} . "</option>\n";
@@ -230,7 +247,7 @@ sub INSTRUMENT_OPTIONS {
 
 
 sub STYLE_OPTIONS {
-    my %styles = Mutopia_Archive::getData("datafiles/styles.dat");
+    my %styles = Mutopia_Archive::getData("$webroot/datafiles/styles.dat");
     my $html = "";
     for my $k (sort keys %styles) {
         $html .= "<option value='$k'>" . $styles{$k} . "</option>\n";
@@ -240,7 +257,7 @@ sub STYLE_OPTIONS {
 
 
 sub STYLE_LIST {
-    my %styles = Mutopia_Archive::getData("datafiles/styles.dat");
+    my %styles = Mutopia_Archive::getData("$webroot/datafiles/styles.dat");
     my $html = "";
     for my $k (sort keys %styles) {
         $html .= $k . ", ";
@@ -251,14 +268,18 @@ sub STYLE_LIST {
 
 sub NUMBER_OF_PIECES {
     # returns the number of pieces (counted from musiccache.dat)
+	
+	# Use Unix text record endings or seek will be off in Windows
+	local $/ = "\n";
 
-    open (CACHE, '<:utf8', 'datafiles/musiccache.dat');
+    open (CACHE, '<:utf8', "$webroot/datafiles/musiccache.dat")
+			or croak "cannot open $webroot/datafiles/musiccache.dat: $!";
     chomp(my $headerlength = <CACHE>);
     my $numberofpieces = 0;
     while (1) {
         chomp(my $templine = <CACHE>);
         if ($templine =~ /^[0-9]+:[0-9]+$/) { $numberofpieces++ }
-	last if $templine eq "**********";
+		last if $templine eq "**********";
     }
     close(CACHE);
     return $numberofpieces;
@@ -271,9 +292,9 @@ sub LATEST_ADDITIONS($) {
 
     #order by ID, most recent first
     my @recent = sort {
-        $a->{id} =~ /-(\d+)$/ or die "invalid id: ", $a->{id};
+        $a->{id} =~ /-(\d+)$/ or croak "invalid id: ", $a->{id};
         my $idA = $1;
-        $b->{id} =~ /-(\d+)$/ or die "invalid id: ", $b->{id};
+        $b->{id} =~ /-(\d+)$/ or croak "invalid id: ", $b->{id};
         my $idB = $1;
 
         return $idB <=> $idA;
@@ -284,7 +305,7 @@ sub LATEST_ADDITIONS($) {
     my $last_piece = (shift) - 1;
     for my $piece(@recent[0 .. $last_piece]) {
         my($date, $id) = $piece->{id} =~ m|-(\d+/\d+/\d+)-(\d+)$|
-                or die "invalid id: " . $piece->{id};
+                or croak "invalid id: " . $piece->{id};
 
         $html .= "<b>$date</b> - ";
         $html .= "<a href='cgibin/piece-info.cgi?id=$id'>";
@@ -306,9 +327,9 @@ sub LATEST_ADDITIONS_RSS($) {
 
     #order by ID, most recent first
     my @recent = sort {
-        $a->{id} =~ /-(\d+)$/ or die "invalid id: ", $a->{id};
+        $a->{id} =~ /-(\d+)$/ or croak "invalid id: ", $a->{id};
         my $idA = $1;
-        $b->{id} =~ /-(\d+)$/ or die "invalid id: ", $b->{id};
+        $b->{id} =~ /-(\d+)$/ or croak "invalid id: ", $b->{id};
         my $idB = $1;
 
         return $idB <=> $idA;
@@ -322,7 +343,7 @@ sub LATEST_ADDITIONS_RSS($) {
     my $last_piece = (shift) - 1;
     for my $piece(@recent[0 .. $last_piece]) {
         my($y, $m, $d, $id) = $piece->{id} =~ m|-(\d+)/(\d+)/(\d+)-(\d+)$|
-                or die "invalid id: " . $piece->{id};
+                or croak "invalid id: " . $piece->{id};
 
         $xml .= "<item>\n";
         $xml .= "<title>" . $piece->{composer} . ": " . $piece->{title} . "</title>\n";
@@ -345,15 +366,19 @@ sub LATEST_ADDITIONS_RSS($) {
 sub ALL_PIECES {
     # returns HTML of links to all pieces in the archive (made from the cache)
     my $html = "";
+	
+	# Use Unix text record endings or seek will be off in Windows
+	local $/ = "\n";
 
-    open (CACHE, '<:utf8', 'datafiles/musiccache.dat');
+    open (CACHE, '<:utf8', "$webroot/datafiles/musiccache.dat")
+			or croak "cannot open $webroot/datafiles/musiccache.dat: $!";
 
     chomp (my $headerlength = <CACHE>);
     seek CACHE, $headerlength, 0;
 
     until (eof CACHE) {
         chomp (my $checkline = <CACHE>);
-        if ($checkline ne "**********") { print "ERROR in the datafile - rebuild cache"; }
+        if ($checkline ne "**********") { carp "ERROR in the datafile - rebuild cache\n"; }
         chomp (my $idno = <CACHE>);
         chomp (my $midrif = <CACHE>);
         chomp (my $musicnm = <CACHE>);
@@ -407,9 +432,10 @@ sub ALL_PIECES {
 sub INCLUDE($) {
     my $infile = shift;
     if (! -e $infile) {
-        $infile = "html-in/" . $infile;
+        $infile = "$webroot/html-in/$infile";
     }
-    open (IN, "<:utf8", $infile) or die "cannot open include file $infile: $!";
+    open (IN, "<:utf8", $infile) 
+		or croak "cannot open include file $webroot/html-in/$infile: $!";
     local $htmlinc = join "", <IN>;
     close IN;
     return $htmlinc;
@@ -747,10 +773,11 @@ Translate a directive name into a perl subroutine call. Kind of magic.
 =item INCLUDE($infile)
 
 Read a file into the input stream. The given input file is checked for
-existence and, if not found, the string is prepended with "html-in/"
-and the open is attempted.
+existence and, if not found, the string is prepended with 
+C<"$webroot/html-in/"> and the open is attempted.  ($webroot is the
+MUTOPIA_WEB environment variable.)
 
-Note that because all template files C<*.html-in and *.rss-in> are
+Note that because all template files C<*.html-in> and C<*.rss-in> are
 processed in C<makeHTML>, include files cannot have the extension,
 C<.html-in>. Include file names can have any extension that doesn't
 end in C<-in> but the preferred extension is C<.html-include>.


### PR DESCRIPTION
I know this seems like (maybe is) a lot of changes, so let me break it down:
- _Change backtick functions_  Perl isn't portable with any backtick functions.  Use Perl equivalents. 
- _Use MUTOPIA_WEB_ File writes and reads need to use the MUTOPIA_WEB environment variable.
- _MSDOS line endings_ `musiccache.dat` and its temp file need to use Linux line endings or the seek will be off.
- _Error reporting_ I changed the `die()`s to `croaks()`s.  The problem with using `die` for error reporting is you can't see where the function was called from.  `croak` fixes that.
- _Formatting_  There were two or three places where the formatting was just wrong and you couldn't see the control structures correctly.  
- _htdocs_ I put all the HTML files in a folder called `htdocs` under MUTOPIA_WEB and added it to `.gitignore`.  This can be changed if necessary.
