### PR TITLE
Simplify footer disclaimer for better wrapping

### DIFF
--- a/html-in/footer.html-include
+++ b/html-in/footer.html-include
@@ -1,10 +1,9 @@
     <footer class="footer">
       <div class="container">
-        <p class="text-center"><u>Disclaimer:</u><br />
-          <small>The Mutopia Project is run by volunteers, and the material within it is provided
-            "as-is". NO WARRANTY of any kind is made, including fitness
-            for any particular purpose.<br />No claim is made as to the accuracy or the
-            factual, editorial or musical correctness of any of the material
+        <p class="text-center"><small>Disclaimer: the Mutopia Project is run by volunteers,
+            and the material within it is provided "as-is". No warranty of any kind is made, 
+            including fitness for any particular purpose. No claim is made as to the accuracy 
+            or the factual, editorial or musical correctness of any of the material
             provided here.</small></p>
       </div>
     </footer>


### PR DESCRIPTION
Removing break elements will allow the text to wrap and fit the width of the screen at any screen size.  Also some other simplifications to make this text more subtle.
