### PR TITLE
Begin simple pagination for non-advanced search

### DIFF
--- a/cgibin/HTMLcommon.pm
+++ b/cgibin/HTMLcommon.pm
@@ -10,6 +10,9 @@ use utf8;
 
 our $VERSION = '0.01';
 
+# Maximum page length for pagination
+our $PAGE_MAX = 10;
+
 # This code was in-line and identical in both modules, so moved here
 # as a function. Returns the QUERY_STRING as an associative array.
 sub queryArgs {

--- a/cgibin/make-table.cgi
+++ b/cgibin/make-table.cgi
@@ -61,9 +61,12 @@ if (!open( CACHE, '<:utf8', "../datafiles/musiccache.dat" )) {
 
 # Read the cache into local variables.
 $matchCount = 0;
+my $pageMax = $HTMLcommon::PAGE_MAX;
+my $pageCount = 0;
+my $startAt = $FORM{'startat'} || 0;
 chomp(my $headerlength = <CACHE>);
 seek CACHE, $headerlength, 0;
-until (eof CACHE) {
+until (eof CACHE || $pageCount >= $startAt + $pageMax) {
     chomp(my $checkline = <CACHE>);
     if ($checkline ne '**********') {
         print qq(<div class="alert alert-danger" role="alert">\n);
@@ -199,7 +202,11 @@ until (eof CACHE) {
     next unless $FORM{'id'} ? ($id =~ /-$FORM{'id'}$/) : 1;
     next unless $FORM{'collection'} ? ($collections =~ /(^|,)$FORM{'collection'}(,|$/) : 1;
 
-    # A match if we got this far. All filtering is done.
+	# All filtering is done, but we may need to skip for pagination
+	$pageCount++;
+	next if $pageCount <= $startAt;
+	
+    # A match if we got this far. 
     $matchCount++;
 
     print qq(<tr><td>\n);       # start a row within the outer table
@@ -330,8 +337,6 @@ until (eof CACHE) {
     print qq(</tr></td>\n);      # outer table row element
 }
 
-close CACHE;
-
 if ($matchCount == 0) {
     print qq(<div class="alert alert-info" role="alert">\n);
     print qq(  Sorry, no matches were found for your search criteria.\n);
@@ -339,5 +344,10 @@ if ($matchCount == 0) {
 }
 
 print qq(</table>\n);           # outer-table
+
+print qq(<a href="make-table.cgi?startat=$pageCount&searchingfor=$FORM{'searchingfor'}">Next $pageMax</a>) 
+		unless eof CACHE;
+
+close CACHE;
 
 HTMLcommon::finishPage();


### PR DESCRIPTION
This is a start at pagination of the non-advanced search.  The maximum page size is kept in HTMLCommon.  There is only forward pagination so far.

Because there is no SQL, the Cache file is searched from the beginning, skipping the pages until we get to $startAt, then prints $pageMax records. 
