### PR TITLE
Retain params when paginating in advanced search

### DIFF
--- a/bin/deploy.pl
+++ b/bin/deploy.pl
@@ -2,6 +2,15 @@
 
 # Deploy files and folder to the htdocs folder of your httpd server.
 # This script would typically be run after Update_website.pl.
+#
+# In a Windows environment, the "shebang" line of the CGI scripts may have to be changed:
+#
+#	#!/usr/bin/perl -wT
+# 	to..
+#	#!perl -wT
+#
+# ...or whatever is appropriate for the environment. 
+
 
 use strict;
 use warnings;

--- a/cgibin/make-table.cgi
+++ b/cgibin/make-table.cgi
@@ -1,4 +1,9 @@
 #!/usr/bin/perl -wT
+
+# The "shebang" line above may have to be changed in a Windows environment:
+#
+#	#!perl -wT
+
 use strict;
 use POSIX;
 use utf8;
@@ -346,7 +351,16 @@ if ($matchCount == 0) {
 
 print qq(</table>\n);           # outer-table
 
-print qq(<a href="make-table.cgi?startat=$pageCount&searchingfor=$FORM{'searchingfor'}">Next $pageMax</a>) 
+print "<a href=\"make-table.cgi?startat=$pageCount"
+		. "&searchingfor=$FORM{'searchingfor'}"
+		. "&Composer=$FORM{'Composer'}"
+		. "&Instrument=$FORM{'Instrument'}"
+		. "&Style=$FORM{'Style'}"
+		. "&timelength=$FORM{'timelength'}"
+		. "&timeunit=$FORM{'timeunit'}"
+		. "&lilyversion=$FORM{'lilyversion'}"
+		. "&preview=$FORM{'preview'}\""
+		. ">Next $pageMax</a>\n"
 		unless eof CACHE;
 
 close CACHE;

--- a/cgibin/piece-info.cgi
+++ b/cgibin/piece-info.cgi
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -wT
 
+# The "shebang" line above may have to be changed in a Windows environment:
+#
+#	#!perl -wT
+
 use strict;
 use POSIX;
 use utf8;


### PR DESCRIPTION
All search parameters are now carried over when paginating.  Comment were put into CGI programs noting that the "shebang" line may need to be changed in a Windows environment.
