### PR TITLE
Add a "--html-only" option to Update_Website.pl

### DIFF
--- a/bin/Update_website.pl
+++ b/bin/Update_website.pl
@@ -9,10 +9,15 @@
 use strict;           # Must declare variables with "my" or "use vars"
 use File::Basename;   # dirname() 
 use File::Find;       # find()
+use Getopt::Long;
 use Cwd;              # getcwd()
 use Mutopia_Archive;  # subroutines for manipulating the archive
 use Mutopia_HTMLGen;  # subroutines for generating HTML
 use vars qw(%RDFData %replacers @rdfFiles);
+
+# Skip creating the cache if all you want is to regenerate the html.
+my $htmlonly;
+GetOptions ("html-only" => \$htmlonly) or die ("Error in command options\n");
 
 # Find the root of our data by assuming the script we are executing is
 # in a 'bin' folder which is a sibling to 'datafiles'. Allow an
@@ -25,12 +30,14 @@ $webroot =~ s|\\|/|g; # change MSDOS file separators
 my $muroot = $ENV{'MUTOPIA_BASE'} || $webroot;
 $muroot =~ s|\\|/|g; # change MSDOS file separators
 
-# Generate datafiles/*  ####################################################
+# Generate datafiles if not just generating the html from existing caches
 my @files = getRDFFileList("$muroot/ftp/");
 %RDFData = getAllRDFData("$muroot/ftp/", @files);
 
-makeCache();        # new format
-makeSearchCache();
+if (!$htmlonly) {
+    makeCache();        # new format
+    makeSearchCache();
+}
 Mutopia_HTMLGen::makeHTML(\%RDFData);
 
 ############################################################################

--- a/cgibin/make-table.cgi
+++ b/cgibin/make-table.cgi
@@ -206,7 +206,7 @@ until (eof CACHE || $pageCount >= $startAt + $pageMax) {
     next unless $FORM{'Instrument'} ? ($instrument =~ /$FORM{'Instrument'}/) : 1;
     next unless $FORM{'Style'} ? ($style eq $FORM{'Style'}) : 1;
     next unless $FORM{'id'} ? ($id =~ /-$FORM{'id'}$/) : 1;
-    next unless $FORM{'collection'} ? ($collections =~ /(^|,)$FORM{'collection'}(,|$/) : 1;
+    next unless $FORM{'collection'} ? ($collections =~ /(^|,)$FORM{'collection'}(,|$)/) : 1;
 
 	# All filtering is done, but we may need to skip for pagination
 	$pageCount++;


### PR DESCRIPTION
The `--html-only` option allows the html to be generated without building the cache files, allowing the site to be generated with a pre-made set of caches. The purpose of this is to allow a prototype site to be built with a fully populated cache _without_ requiring the developer to "compile" all pieces in the archive.
