### PR TITLE
Updated item lists

### DIFF
--- a/css/mutopia.css
+++ b/css/mutopia.css
@@ -50,6 +50,36 @@ p.adv-search {
     margin: 0 -15px 15px;
 }
 
+.top-page-sep {
+    border-top: 2px solid rgb(200, 200, 200);
+    margin-top: 20px;
+}
+
+.mid-page-sep {
+    border-top: 2px solid rgb(200, 200, 200);
+    margin-top: 20px;
+    margin-bottom: 20px;
+    padding-bottom: 20px;
+}
+
+.bottom-page-sep {
+    border-top: 2px solid rgb(200, 200, 200);
+    margin-top: 20px;
+    border-bottom: 2px solid rgb(200, 200, 200);
+    margin-bottom: 20px;
+    padding-bottom: 20px;
+}
+
+.browse-list ul {
+    padding-left: 0;
+}
+.browse-list ul li {
+    color: rgb(130, 130, 130);
+    list-style-type: none;
+    padding-top: .5em;
+/*    line-height: 2;*/
+}
+
 th { text-align: center; }
 
 /* Browse table styling */

--- a/html-in/collections.html-in
+++ b/html-in/collections.html-in
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	[[ INCLUDE("head-pre.html-include") ]]
+	<title>Mutopia: Browse Collections</title>
+	[[ INCLUDE("head-post.html-include") ]]
+<body>
+    [[ INCLUDE("nav-pre.html-include") ]]
+    [[ INDEX("latestadditions") ]]
+    [[ INCLUDE("nav-post.html-include") ]]
+    [[ INCLUDE("jumbotron-search.html-include") ]]
+	
+	<div class="container">
+      <div class="row browse-list">
+        <h2>Browse Collections</h2>
+	      [[ BROWSE_COLLECTIONS() ]]
+      </div> <!-- row -->
+    </div> <!-- .container -->
+	
+	[[ INCLUDE("footer.html-include") ]]
+</body>
+</html>

--- a/html-in/composers.html-in
+++ b/html-in/composers.html-in
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	[[ INCLUDE("head-pre.html-include") ]]
+	<title>Mutopia: Browse by Composer</title>
+	[[ INCLUDE("head-post.html-include") ]]
+<body>
+    [[ INCLUDE("nav-pre.html-include") ]]
+    [[ INDEX("latestadditions") ]]
+    [[ INCLUDE("nav-post.html-include") ]]
+    [[ INCLUDE("jumbotron-search.html-include") ]]
+	
+	<div class="container">
+      <div class="row">
+        <h2>Browse by Composer</h2>
+	      [[ TOP_COMPOSERS(0) ]]
+      </div> <!-- row -->
+    </div> <!-- .container -->
+	
+	[[ INCLUDE("footer.html-include") ]]
+</body>
+</html>

--- a/html-in/index.html-in
+++ b/html-in/index.html-in
@@ -5,7 +5,7 @@
   [[ INCLUDE("head-post.html-include") ]]
 
   <body>
-  
+
     <!-- Nagigation Bar -->
     [[ INCLUDE("nav-pre.html-include") ]]
     [[ INDEX("index") ]]
@@ -13,87 +13,90 @@
     [[ INCLUDE("jumbotron-search.html-include") ]]
 
     <div class="container">
-	
+
       <!-- Top Text, row 1 -->
       <div class="row">
         <div class="col-xs-12">
           <h2 class="text-left" id="free-for-everyone">Free Sheet Music for Everyone</h2>
-          
+
           <p class="lead">[[ NUMBER_OF_PIECES ]] pieces of music – free to download, modify, print, copy, distribute, perform, and record – all in the Public Domain or under Creative Commons licenses, in PDF, MIDI, and editable <a href="http://lilypond.org/">LilyPond</a> file formats.
             <a href="#site-overview" class="btn-default btn-sm active" role="button">More <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
         </div>
       </div>
 
       <!-- Browse Options, row 2 -->
-      <div class="row" style="border-top: 2px solid rgb(200, 200, 200); margin-top:20px;">
-      
+      <div class="row top-page-sep">
+
         <!-- Lastest Additions -->
-        <div class="col-sm-3 col-md-3">  
-          <h3 class="tet-center"><span style="font-size: small; white-space: nowrap;">Browse</span><br>Latest Additions</h3>
+        <div class="col-sm-3 col-md-3">
+          <h3><a href="latestadditions.html">Latest Additions</a></h3>
           [[ LATEST_ADDITIONS(7) ]]
           <p><a href="latestadditions.html" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
-        </div> 
-      
+        </div>
+
         <!-- Instruments -->
         <div class="col-sm-2 col-md-2">
-          <h3><span style="font-size: small; white-space: nowrap;">Browse by</span><br>Instrument</h3>
-          <div class="" style="color: rgb(130, 130, 130);">
-            [[ TOP_INSTRUMENTS(15) ]] 
+          <h3><a href="instruments.html">Instruments</a></h3>
+          <div class="browse-list">
+            [[ TOP_INSTRUMENTS(15) ]]
+          <p><a href="instruments.html" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
           </div>
-          <p><a href="browse.html#browse_details" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
         </div>
-        
+
         <!-- Composer -->
         <div class="col-sm-2 col-md-2">
-          <h3><span style="font-size: small; white-space: nowrap;">Browse by</span><br>Composer</h3>
-          <div style="color: rgb(130, 130, 130);">
+          <h3><a href="composers.html">Composers</a></h3>
+          <div class="browse-list">
             [[ TOP_COMPOSERS(15) ]]
           </div>
-          <p><a href="browse.html#browse_details" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
+          <p><a href="composers.html" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
         </div>
-        
+
         <!-- Styles -->
         <div class="col-sm-2 col-md-2">
-          <h3><span style="font-size: small; white-space: nowrap;">Browse by</span><br>Style</h3>
-          <div style="color: rgb(130, 130, 130);">
+          <h3>Styles</h3>
+          <div class="browse-list">
             [[ TOP_STYLES(15) ]]
           </div>
+          <!-- no button here because this is the entire list -->
         </div>
-        
+
         <!-- Collections -->
         <div class="col-sm-3">
-          <h3><span style="font-size: small; white-space: nowrap;">Browse</span><br>Collections</h3>
-          [[ TOP_COLLECTIONS(15) ]]
-          <p><a href="browse.html#browse_details" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
+          <h3><a href="collections.html" alt="Show all collections">Collections</a></h3>
+          <div class="browse-list">
+            [[ TOP_COLLECTIONS(15) ]]
+          <p><a href="collections.html" class="btn-default btn-sm active" role="button">Show All <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></p>
+          </div>
         </div>
-      
-      </div> <!-- row -->
-      
-      <!-- What we offer and Usage, row 3 -->
-      <span><a name="site-overview">&nbsp;</a><br \>
 
-      <div class="row" style="border-top: 2px solid rgb(200, 200, 200); margin-top:20px; margin-bottom:20px; padding-bottom:20px;">
-      
+      </div> <!-- row -->
+
+      <!-- What we offer and Usage, row 3 -->
+      <a name="site-overview"><span>&nbsp;</span></a><br \>
+
+      <div class="row mid-page-sep">
+
         <div class="col-sm-6 col-md-6">
           <h3>Classical and Contemporary</h3>
-          
+
           <p>The Mutopia Project offers sheet music editions of classical music for free download. These are based on editions in the public domain. A team of volunteers typesets the music using <a href="http://lilypond.org/">LilyPond</a> software. Why not join them?! See the <a href="contribute.html">page on how to contribute</a> for more information.</p>
-          
+
           <p>We also offer a growing number of modern editions, arrangements and new music. The respective editors, arrangers and composers have chosen to make these works freely available.</p>
         </div>
-        
+
         <div class="col-sm-6 col-md-6">
           <h3>Usage of the Music</h3>
-          
+
           <p>All of the music on Mutopia may be freely downloaded, printed, copied, distributed, modified, performed and recorded. Music is supplied as PDF files for easy printing on either A4 or US Letter paper. The LilyPond source files are also available, which allow you to make your own editions based on ours. Computer-generated audio previews of the music are available as MIDI files, to give you a rough idea of what the music sounds like.</p>
-          
+
           <p>Most of our music is distributed under <a href="http://creativecommons.org/">Creative Commons</a> licenses. Each piece clearly lists what license it is distributed under. For precise details of what each license permits, see the <a href="legal.html">license details page</a>.</p>
          </div>
-         
+
       </div> <!-- row -->
-      
+
       <!-- RSS, Acknowledgements, Bandwidth, row 4 -->
-      <div class="row" style="border-top: 2px solid rgb(200, 200, 200); margin-top:20px; border-bottom: 2px solid rgb(200, 200, 200); margin-bottom:20px; padding-bottom:20px;">
+      <div class="row bottom-page-sep">
 
         <div class="col-sm-4">
           <h3>RSS Feed &nbsp; &nbsp; <a href="latestadditions.rss"><img src="images/feed-icon-28x28.png" alt="RSS" class="noborder" width="28" height="28" /></a></h3>
@@ -105,25 +108,25 @@
 
         <div class="col-sm-4">
           <h3>Acknowledgements</h3>
-          
+
           <p>All music on this site has been typeset using <a href="http://lilypond.org/">LilyPond</a>.</p>
-          
+
           <p>Many thanks to Eric Praetzel at the <a href="http://www.uwaterloo.ca/">University of Waterloo</a> for the loan of our web space and bandwidth.</p>
-          
+
           <p>Thanks also to all the people who have typeset music so that it can be freely available.  Credits to individual typesetters appear with each piece of music on Mutopia.</p>
         </div>
-          
+
         <div class="col-sm-4">
           <h3>Save Our Bandwidth</h3>
-          
-          <p class="txt-center">Use a mirror: 
+
+          <p class="txt-center">Use a mirror:
             <a href="http://www.mutopiaproject.org/" title="Main site in Canada"><b>Canada</b></a> |
             <a href="http://eremita.di.uminho.pt/mutopia/" title="Mirror in Portugal">Portugal</a>
           </p>
         </div>
-        
+
       </div> <!-- row -->
-      
+
     </div> <!-- container -->
 
     [[ INCLUDE("footer.html-include") ]]

--- a/html-in/instruments.html-in
+++ b/html-in/instruments.html-in
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	[[ INCLUDE("head-pre.html-include") ]]
+	<title>Mutopia: Browse by Instrument</title>
+	[[ INCLUDE("head-post.html-include") ]]
+<body>
+    [[ INCLUDE("nav-pre.html-include") ]]
+    [[ INDEX("latestadditions") ]]
+    [[ INCLUDE("nav-post.html-include") ]]
+    [[ INCLUDE("jumbotron-search.html-include") ]]
+	
+	<div class="container">
+      <div class="row browse-list">
+        <h2>Browse by Instrument</h2>
+	      [[ TOP_INSTRUMENTS(0) ]]
+      </div> <!-- row -->
+    </div> <!-- .container -->
+	
+	[[ INCLUDE("footer.html-include") ]]
+</body>
+</html>

--- a/src/Mutopia_HTMLGen/lib/Mutopia_HTMLGen.pm
+++ b/src/Mutopia_HTMLGen/lib/Mutopia_HTMLGen.pm
@@ -141,9 +141,20 @@ sub BROWSE_BY_COMPOSER {
 
 sub TOP_COMPOSERS($) {
     my $maxNumber = shift;
-    my $count = 0;
     my %comps = Mutopia_Archive::getData("$webroot/datafiles/composers.dat");
     my $html = "";
+    my $cols = 1;
+    my $item_count = scalar keys %comps;
+    if ($maxNumber < 1) {
+        $maxNumber = $item_count;
+        $cols = 2;
+    }
+
+    $html .= "<div class=\"col-md-6 browse-list\">" if ($cols > 1);
+    $html .= "<ul>\n";
+    my $count = 0;
+    my $on_column = 0;
+    my $per_column = $item_count / $cols;
     for my $k (sort {Mutopia_Archive::byComposer($a,$b)} keys %comps) {
         last if $count > $maxNumber;
         
@@ -159,12 +170,22 @@ sub TOP_COMPOSERS($) {
 		} until (($finish == 1) || (eof SEARCHCACHE));
         close(SEARCHCACHE);
         
-        $comps{$k} =~ /^([^(]+)\s*\(/; # Strip off date
-        my $compName = $1;
-        $html .= "<p><a href='cgibin/make-table.cgi?Composer=$k'>";
-        $html .= $compName . "</a> [$noofpieces]</p>\n";
+        my $compName = $comps{$k};
+        $compName =~ s/\s*\(.*$// unless ($cols > 1); # Strip off date
+        $html .= "<li><a href='cgibin/make-table.cgi?Composer=$k'>";
+        $html .= $compName . "</a> [$noofpieces]</li>\n";
+        if ($cols > 1) {
+            my $at_col = int($count / $per_column);
+            if ($at_col != $on_column) {
+                $html .= "</ul></div><div class=\"col-md-6 browse-list\"><ul>\n";
+                $on_column = $at_col;
+            }
+        }
         $count++;
     }
+    $html .= "</ul>";
+    $html .= "</div>" if ($cols > 1);
+
     return $html;
 }
 
@@ -197,9 +218,21 @@ sub BROWSE_BY_INSTRUMENT {
 
 sub TOP_INSTRUMENTS($) {
     my $maxNumber = shift;
-    my $count = 0;
     my %insts = Mutopia_Archive::getData("$webroot/datafiles/instruments.dat");
     my $html = "";
+    my $cols = 1;
+    my $item_count = scalar keys %insts;
+    if ($maxNumber < 1) { 
+        $maxNumber = $item_count;
+        $cols = 3;
+    }
+
+    $html .= "<div class=\"col-md-4\">\n" if ($cols > 1);
+    $html .= "<ul>\n";
+
+    my $count = 0;
+    my $on_column = 0;
+    my $per_column = $item_count / $cols;
     for my $k (sort {Mutopia_Archive::byInstrument($a,$b)} keys %insts) {
         last if $count > $maxNumber;
             
@@ -217,10 +250,20 @@ sub TOP_INSTRUMENTS($) {
         } until (($finish == 1) || (eof SEARCHCACHE));
         close(SEARCHCACHE);
 
-        $html .= "<p><a href='cgibin/make-table.cgi?Instrument=$k'>";
-        $html .= $insts{$k} . "</a> [$noofpieces]</p>\n";
+        $html .= "<li><a href='cgibin/make-table.cgi?Instrument=$k'>";
+        $html .= $insts{$k} . "</a> [$noofpieces]</li>\n";
+        if ($cols > 1) {
+            my $at_col = int($count / $per_column);
+            if ($at_col != $on_column) {
+                $html .= "</ul></div><div class=\"col-md-4 browse-list\"><ul>\n";
+                $on_column = $at_col;
+            }
+        }
         $count++;
     }
+    $html .= "</ul>";
+    $html .= "</div>" if ($cols > 1);
+    
     return $html;
 }
 
@@ -253,7 +296,7 @@ sub TOP_STYLES($) {
     my $maxNumber = shift;
     my $count = 0;
     my %styles = Mutopia_Archive::getData("$webroot/datafiles/styles.dat");
-    my $html = "";
+    my $html = "<ul>\n";
     for my $k (sort keys %styles) {
         last if $count > $maxNumber;
         
@@ -269,10 +312,11 @@ sub TOP_STYLES($) {
         } until (($finish == 1) || (eof SEARCHCACHE));
         close(SEARCHCACHE);
 
-        $html .= "<p><a href='cgibin/make-table.cgi?Style=$k'>";
-        $html .= $styles{$k} . "</a> [$noofpieces]</p>\n";
+        $html .= "<li><a href='cgibin/make-table.cgi?Style=$k'>";
+        $html .= $styles{$k} . "</a> [$noofpieces]</li>\n";
         $count++
     }
+    $html .= "</ul>";
     return $html;
 }
 
@@ -307,7 +351,7 @@ sub TOP_COLLECTIONS($) {
     my $lineread;
     my $colname;
     my $coldesc;
-    my $html = "";
+    my $html = "<ul>\n";
 
     open (COLLECTIONS, '<:utf8', "$webroot/datafiles/collections.dat")
             or croak "cannot open $webroot/datafiles/collections.dat: $!";
@@ -317,10 +361,11 @@ sub TOP_COLLECTIONS($) {
         $colname = $1;
         $coldesc = $2;
 
-        $html .= "<p><a href=\"cgibin/make-table.cgi?collection=";
-        $html .= $colname . "&amp;preview=1\">" . $coldesc . "</a></p>\n";
+        $html .= "<li><a href=\"cgibin/make-table.cgi?collection=";
+        $html .= $colname . "&amp;preview=1\">" . $coldesc . "</a></li>\n";
         $count++;
     } 
+    $html .= "</ul>";
 
     close (COLLECTIONS);
 


### PR DESCRIPTION
Added separate browse pages for instruments, composers, and collections. These are accessible from the home page. The "Browse" page remains unchanged (same as prototype) but these additional pages allow direct links from, for example, the instrument list 'show all' button directly to a page containing only instruments.

CSS was modified to allow the item lists, previously done with paragraphs, to now be done as CSS lists. Some style directives embedded in the html code have been moved to our CSS file as well.
