### PR TITLE
Ignoring accents when searching keywords

### DIFF
--- a/css/mutopia.css
+++ b/css/mutopia.css
@@ -164,6 +164,9 @@ th a, th a:hover, th a:active {
     text-decoration: none;
 }
 
+.bench {
+    color: rgb(130, 130, 130);
+}
 
 @media screen and (max-width: 767px) {
     #logo-div {


### PR DESCRIPTION
Added a UTF-8 level 1 collator for matching. Since this increases search times I added a search time benchmark output at the bottom of the page.
