### PR TITLE
Fix instrument matches 

### DIFF
--- a/cgibin/make-table.cgi
+++ b/cgibin/make-table.cgi
@@ -203,7 +203,7 @@ until (eof CACHE || $pageCount >= $startAt + $pageMax) {
     next unless $go;
 
     # Apply remaining filters in the input form
-    next unless $FORM{'Instrument'} ? ($instrument =~ /$FORM{'Instrument'}/) : 1;
+    next unless $FORM{'Instrument'} ? ($instrument =~ /$FORM{'Instrument'}(s|es|[\W]|$)/) : 1;
     next unless $FORM{'Style'} ? ($style eq $FORM{'Style'}) : 1;
     next unless $FORM{'id'} ? ($id =~ /-$FORM{'id'}$/) : 1;
     next unless $FORM{'collection'} ? ($collections =~ /(^|,)$FORM{'collection'}(,|$)/) : 1;

--- a/src/Mutopia_HTMLGen/lib/Mutopia_HTMLGen.pm
+++ b/src/Mutopia_HTMLGen/lib/Mutopia_HTMLGen.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -wT
+#!/usr/bin/perl -w
 #
 # Mutopia_HTMLGen.pm
 # Subroutines to help with generating HTML pages from html-in/* files.
@@ -203,7 +203,7 @@ sub BROWSE_BY_INSTRUMENT {
         do {
             chomp(my $templine = <SEARCHCACHE>);
             if ( ($templine =~ /^instruments:/) &&
-               ( $templine =~ /$k/ )) { $noofpieces++ }
+               ( $templine =~ /$k(s|es|[\W])/ )) { $noofpieces++ }
             if (($k eq "Harp") and ($templine =~ /Harpsichord/)) { $noofpieces-- }
             if ($templine =~ /^licence/) { $finish = 1 }
         } until (($finish == 1) || (eof SEARCHCACHE));
@@ -244,7 +244,7 @@ sub TOP_INSTRUMENTS($) {
         do {
             chomp(my $templine = <SEARCHCACHE>);
             if ( ($templine =~ /^instruments:/) &&
-               ( $templine =~ /$k/ )) { $noofpieces++ }
+               ( $templine =~ /$k(s|es|[\W])/ )) { $noofpieces++ }
             if (($k eq "Harp") and ($templine =~ /Harpsichord/)) { $noofpieces-- }
             if ($templine =~ /^licence/) { $finish = 1 }
         } until (($finish == 1) || (eof SEARCHCACHE));


### PR DESCRIPTION
This needs a review but I think it solves this particular problem.

Caveat: the core of this problem is that we determine some of our page information (number of pieces that use a particular instrument, for example) from the `searchcache.dat` file and then perform searches on the `musiccache.dat`. This may seem benign but it means that our regex search pattern is duplicated in 3 places.

Also fixes the problem with Harp counts, which should never have matched piece 1743.

Close #83 
