### PR TITLE
Add in-progress listing for KV 488

### DIFF
--- a/html-in/projects.html-in
+++ b/html-in/projects.html-in
@@ -94,6 +94,7 @@
             <li>Daniel Burrows &lt;dburrows (at) brown.edu&gt; - Mozart's Piano Sonata in G major, K 283</li>
             <li>Jost Schenck &lt;jost (at) schenck.de&gt; - Mozart's Sonata No. 13 in C major</li>
             <li>Guillaume Viel &lt;guillaume.viel (at) openfarm.fr&gt; - Mozart's Piano concerto #20 in D minor KV466</li>
+            <li>William Chargin &lt;wchargin (at) gmail.com&gt; - Mozart's Piano Concerto No. 23 in A major, KV 488</li>
             <li>Martin Willett &lt;mwillett1 (at) cox.net&gt; - Mozart's Ein Musikalischer Spass (A Musical Joke), Divertimento for Orchestra KV 522, movements 1-4</li>
             <li>Chris Matlak - <b>Cancelled</b> - Mozart's String Quartet in D Major (K. 499). Work can be downloaded: <a href="unfinished/K499.zip">K499.zip</a></li>
             <li>Guillermo Ballester Valor &lt;gbv (at) oxixares.com&gt; - Mozart's "Jupiter" Symphony no. 41 in C major, K 551</li>


### PR DESCRIPTION
I'm pushing my work in progress to the `kv488` branch of my GitHub fork
of the main Mutopia repository:
<https://github.com/wchargin/MutopiaProject/tree/kv488>

Please note that I plan to continue to force-push to this branch.

wchargin-branch: in-progress-kv488